### PR TITLE
Add optional virtualenv_pip_version because anything above 1.4 sucks due...

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,12 @@
   sudo_user: "{{ virtualenv_user }}"
   when: virtualenv_activate.stat.exists != true
 
+- name: Reinstall pip version ({{ virtualenv_pip_version }})
+  pip: name=pip version={{ virtualenv_pip_version }} virtualenv={{ virtualenv_path }}
+  sudo: yes
+  sudo_user: "{{ virtualenv_user }}"
+  when: virtualenv_pip_version is defined
+
 - name: Install requirements
   pip: requirements={{ virtualenv_requirements_file }} virtualenv={{ virtualenv_path }}
   sudo: yes


### PR DESCRIPTION
This allows one to define `virtualenv_pip_version` which will down/upgrade the virtualenv to use whatever version of pip is required (ie to avoid the ridiculous, ill-considered --allow-external flags in 1.5+).
