### PR TITLE
Always process dependency links when installing requirements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   when: virtualenv_pip_version is defined
 
 - name: Install requirements
-  pip: requirements={{ virtualenv_requirements_file }} virtualenv={{ virtualenv_path }}
+  pip: requirements={{ virtualenv_requirements_file }} virtualenv={{ virtualenv_path }} extra_args='--process-dependency-links'
   sudo: yes
   sudo_user: "{{ virtualenv_user }}"
   when: virtualenv_requirements_file is defined


### PR DESCRIPTION
Hi @sujaymansingh!

pip doesnt automatically process dependency links so I thought it would be good to always do it, as it can lead to failures if you have any and are trying to use a venv!