### PR TITLE
Add optional virtualenv version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ If you want to have system site packages, use
 ```
     virtualenv_site_packages: "--system-site-packages"
 ```
+
+If you want to specify virtualenv version, use
+
+```
+  virtualenv_version : "13.0.0"
+```

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ If you want to specify virtualenv version, use
 ```
   virtualenv_version : "13.0.0"
 ```
+
+Otherwise the latest virtualenv version will be installed if `virtualenv_version` is not defined.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,15 @@
   with_items: [build-essential, python-dev, python-pip]
   sudo: yes
 
-- name: Install core virtualenv
+- name: Install virtualenv version ({{ virtualenv_version }})
+  command: pip install virtualenv=={{ virtualenv_version }}
+  sudo: yes
+  when: virtualenv_version is defined
+
+- name: Install latest virtualenv version
   command: pip install virtualenv
   sudo: yes
+  when: virtualenv_version is not defined
 
 - name: Create folder for virtualenv
   file: state=directory owner={{ virtualenv_user }} group={{ virtualenv_group }} path={{ virtualenv_path }}


### PR DESCRIPTION
Hi @sujaymansingh! 

The latest version of virtualenv causes some problems with certain packages (due to it using the latest version of setuptools see here: https://bitbucket.org/pypa/setuptools/issues/502/packaging-164-does-not-allow-whitepace) This change allows users to specify a specific version in order to avoid these problems when needed.
